### PR TITLE
Modernize code for PHP 8

### DIFF
--- a/app/controller/Controlmain.php
+++ b/app/controller/Controlmain.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Control;
 
@@ -7,73 +8,55 @@ use Tools\CreateOp;
 use Tools\MontHtml;
 use Tools\ToolsAn;
 
-
 class Controlmain extends Controller
 {
-    
-    function formGenerete()
+    public function formGenerete(): void
     {
-        if(ToolsAn::post('todosAleatory'))
-        {
+        if (ToolsAn::post('todosAleatory') !== false) {
+            $vd  = new ToolsAn();
+            $vd2 = new ToolsAn();
 
-            $vd = new ToolsAn;
-            
-            $vd2 = new ToolsAn;
+            $ctnA = $vd->validate('quantA', 'number', 'min:1');
+            $ctnB = $vd2->validate('quantB', 'number', 'min:2');
 
-            $ctnA =  $vd->validate('quantA','number','min:1');
+            if ($ctnA === false) {
+                $ctnA = 1;
+            }
+            if ($ctnB === false) {
+                $ctnB = 900;
+            }
 
-            $ctnB =  $vd2->validate('quantB','number','min:2');
-
-            if($ctnA == false): $ctnA = 1;endif;
-
-            if($ctnB == false): $ctnB = 900;endif;
-            
             $v3 = ToolsAn::filtArray(ToolsAn::post('quant'));
-            
-            if($v3 == false): $v3=10;endif;
+            if ($v3 === false) {
+                $v3 = [10];
+            }
 
             $v4 = ToolsAn::filtArray(ToolsAn::post('operation'));
-            
-            $quest = new CreateOp();
 
-            $quest->CreateOp($ctnA,$ctnB);
-            
-            if(!$v4):
+            $quest = new CreateOp($ctnA, $ctnB);
 
-                if(isset($v3[0])): $v3 = $v3[0];endif;
-               
-                $resta = $quest->creatEverEqual($v3);
-
-                // ToolsAn::dd($resta);
-            elseif(count($v4) == 1 and count($v3) == 1):
-
-                $resta = $quest->createOperetionUnic($v3[0],$v4[0]);
-
-            else:
-
-                $temp = array();
-
-                for($i=0; $i < count($v4); $i++)
-                {
-                    array_push($temp[$v4[$i]]);
-
-                    $temp[$v4[$i]] = $v3[$i];
-
+            if (!$v4) {
+                if (isset($v3[0])) {
+                    $v3 = $v3[0];
                 }
-
+                $resta = $quest->creatEverEqual((int)$v3);
+            } elseif (count($v4) === 1 && count($v3) === 1) {
+                $resta = $quest->createOperetionUnic((int)$v3[0], (string)$v4[0]);
+            } else {
+                $temp = [];
+                for ($i = 0; $i < count($v4); $i++) {
+                    $temp[$v4[$i]] = $v3[$i];
+                }
                 $resta = $quest->createdFromAnArray($temp);
-
-            endif;
-
+            }
         }
 
-        $htm = new MontHtml;
-        $html = $htm->mountHtml($resta);
-        $env = array(
-            "contets" => $html
-        );
+        $htm  = new MontHtml();
+        $html = $htm->mountHtml($resta ?? []);
+        $env  = [
+            'contets' => $html,
+        ];
 
-        echo $this->load('pgQuests',$env);
-        
+        echo $this->load('pgQuests', $env);
     }
 }

--- a/app/controller/ErrorsController.php
+++ b/app/controller/ErrorsController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Control;
 
@@ -6,8 +7,8 @@ use Core\Controller;
 
 class ErrorsController extends Controller
 {
-    function pgNotFound(){
-        // echo "oii";
+    public function pgNotFound(): void
+    {
         echo $this->load('msgErro');
     }
 }

--- a/app/controller/PagesController.php
+++ b/app/controller/PagesController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Control;
 
@@ -6,10 +7,13 @@ use Core\Controller;
 
 class PagesController extends Controller
 {
-    function indexPage(){
+    public function indexPage(): void
+    {
         echo $this->load('themaIndex');
     }
-    function formQ(){
+
+    public function formQ(): void
+    {
         echo $this->load('screenIni');
     }
 }

--- a/app/core/Controller.php
+++ b/app/core/Controller.php
@@ -1,14 +1,15 @@
 <?php
+declare(strict_types=1);
 
 namespace Core;
 
-class Controller{
-
-    function load(string $view, $param = []){
+class Controller
+{
+    public function load(string $view, array $param = []): string
+    {
         $twig = new \Twig\Environment(
-            new \Twig\Loader\FilesystemLoader(HOME.'/app/view')
+            new \Twig\Loader\FilesystemLoader(HOME . '/app/view')
         );
-        return $twig->render($view.".php", $param);
+        return $twig->render($view . '.php', $param);
     }
-
 }

--- a/app/src/CreateOp.php
+++ b/app/src/CreateOp.php
@@ -1,83 +1,78 @@
 <?php
+declare(strict_types=1);
 
 namespace Tools;
 
-class CreateOp{
-    //Variable
-    private $intervaloA;
-    private $intervaloB;
+class CreateOp
+{
+    private int $intervaloA;
+    private int $intervaloB;
 
-    //Constructor
-    function CreateOp(int $inta, int $intab)
+    public function __construct(int $inta, int $intab)
     {
         $this->intervaloA = $inta;
-        
         $this->intervaloB = $intab;
     }
 
-    function getIntervaloA(){
+    public function getIntervaloA(): int
+    {
         return $this->intervaloA;
     }
-    function getIntervaloB(){
+
+    public function getIntervaloB(): int
+    {
         return $this->intervaloB;
     }
 
     
 
-    //Generates the values 
-    private function valueGenerator()
+    //Generates the values
+    private function valueGenerator(): int
     {
-        $val = rand($this->intervaloA, $this->intervaloB);
-
-        return $val;
+        return rand($this->intervaloA, $this->intervaloB);
     }
-    // Recebe a quantidade de equações e a opeção, e retorna um array.
-    function createOperetionUnic(int $qnt, string $operation)
+
+    // Recebe a quantidade de equações e a operação, e retorna um array.
+    public function createOperetionUnic(int $qnt, string $operation): array
     {
-        $quest = array();
-
-        for($ct=0; $ct < $qnt; $ct++){
-
-            array_push($quest,$this->crtArrayOps($ct, $operation));
-
+        $quest = [];
+        for ($ct = 0; $ct < $qnt; $ct++) {
+            $quest[] = $this->crtArrayOps($ct, $operation);
         }
-
         return $quest;
     }
+
     //Gera com especificações
-    function createdFromAnArray(array $conf)
+    public function createdFromAnArray(array $conf): array
     {
-        $quest = array();
-
+        $quest = [];
         $ctn = 0;
-
-        foreach ($conf as $operation => $qnt){
-
-            for($a=0; $a < $qnt; $a++){
-
-                array_push($quest, $this->crtArrayOps($ctn,"$operation"));
-
+        foreach ($conf as $operation => $qnt) {
+            for ($a = 0; $a < $qnt; $a++) {
+                $quest[] = $this->crtArrayOps($ctn, (string)$operation);
             }
         }
+        return $quest;
+    }
 
-        return $quest;
-    }
     //Gera com todas as operações.
-    function creatEverEqual(int $qnt)
+    public function creatEverEqual(int $qnt): array
     {
-        $oper = array(
-            1 => "+",
-            2 => "-",
-            3 => "*",
-            4 => "/"
-        );
-        $quest = array();
-        for($ct=0; $ct < $qnt; $ct++){
-            array_push($quest,$this->crtArrayOps($ct, $oper[rand(1,4)]));
-        }        
+        $oper = [
+            1 => '+',
+            2 => '-',
+            3 => '*',
+            4 => '/',
+        ];
+        $quest = [];
+        for ($ct = 0; $ct < $qnt; $ct++) {
+            $quest[] = $this->crtArrayOps($ct, $oper[rand(1, 4)]);
+        }
         return $quest;
     }
-    function crtArrayOps(int $ct,string $operation){
+
+    public function crtArrayOps(int $ct, string $operation): array
+    {
         $valueA = $this->valueGenerator();
         $valueB = $this->valueGenerator();
         switch($operation){
@@ -116,25 +111,33 @@ class CreateOp{
     }
 
     //Faz os Cálculos
-    private function calcAddition($vA, $vB){
+    private function calcAddition(int|float $vA, int|float $vB): array
+    {
         $opA = $vA + $vB;
-        return $this->grOptions($opA,0);    
-    }    
-    private function calcSubtraction($vA, $vB){
-         $opA = $vA - $vB;
-        return $this->grOptions($opA,0);        
-    }
-    private function calcMultiplication($vA, $vB){
-        $opA = $vA * $vB;
-        return $this->grOptions($opA,0);   
-    }
-    private function calcDivision($vA,$vB){
-        $opA = $vA / $vB;
-        return $this->grOptions($opA,0);   
+        return $this->grOptions($opA, 0);
     }
 
-    private function grOptions($opA,$csD){
-        $op = rand (1,4);
+    private function calcSubtraction(int|float $vA, int|float $vB): array
+    {
+        $opA = $vA - $vB;
+        return $this->grOptions($opA, 0);
+    }
+
+    private function calcMultiplication(int|float $vA, int|float $vB): array
+    {
+        $opA = $vA * $vB;
+        return $this->grOptions($opA, 0);
+    }
+
+    private function calcDivision(int|float $vA, int|float $vB): array
+    {
+        $opA = $vA / $vB;
+        return $this->grOptions($opA, 0);
+    }
+
+    private function grOptions(float $opA, int $csD): array
+    {
+        $op = rand(1, 4);
         switch($op){
             case 1:
                 $opB = $opA + rand(2,5);

--- a/app/src/MontHtml.php
+++ b/app/src/MontHtml.php
@@ -1,39 +1,40 @@
 <?php
+declare(strict_types=1);
 
 namespace Tools;
 
-class MontHtml{
-
-    function mountHtml($result)
+class MontHtml
+{
+    /**
+     * @param array $result
+     */
+    public function mountHtml(array $result): string
     {
-        $html = "";
-        $ct = 0;
-        foreach($result as $values)
-        {
-            foreach($values as $value)
-            {
+        $html = '';
+        $ct   = 0;
+        foreach ($result as $values) {
+            foreach ($values as $value) {
                 $html .= "<div class='uniQ'>\n";
-
-                $html .= "<p>".$value['ValueA']." ".$value['Operation']." ".$value['ValueB']."</p>\n";
-                
+                $html .= "<p>{$value['ValueA']} {$value['Operation']} {$value['ValueB']}</p>\n";
                 $html .= "<div class='btns'>\n";
-                $fuc = "vrQ($ct,'First','".$value['Options']['Result']."')";
-                $html .= "<button onclick=$fuc id='".$ct."First'>".$value['Options']['First']."</button>\n";
 
-                $fuc = "vrQ($ct,'Second','".$value['Options']['Result']."')";
-                $html .= "<button onclick=$fuc id='".$ct."Second'>".$value['Options']['Second']."</button>\n";
+                $fuc = "vrQ($ct,'First','{$value['Options']['Result']}')";
+                $html .= "<button onclick=$fuc id='{$ct}First'>{$value['Options']['First']}</button>\n";
 
-                $fuc = "vrQ($ct,'Third','".$value['Options']['Result']."')";
-                $html .= "<button onclick=$fuc id='".$ct."Third'>".$value['Options']['Third']."</button>\n";
+                $fuc = "vrQ($ct,'Second','{$value['Options']['Result']}')";
+                $html .= "<button onclick=$fuc id='{$ct}Second'>{$value['Options']['Second']}</button>\n";
 
-                $fuc = "vrQ($ct,'Fourth','".$value['Options']['Result']."')";
-                $html .= "<button onclick=$fuc id='".$ct."Fourth'>".$value['Options']['Fourth']."</button>\n";
-                $html .="</div>\n";
+                $fuc = "vrQ($ct,'Third','{$value['Options']['Result']}')";
+                $html .= "<button onclick=$fuc id='{$ct}Third'>{$value['Options']['Third']}</button>\n";
+
+                $fuc = "vrQ($ct,'Fourth','{$value['Options']['Result']}')";
+                $html .= "<button onclick=$fuc id='{$ct}Fourth'>{$value['Options']['Fourth']}</button>\n";
+
                 $html .= "</div>\n";
-                $ct++;        
+                $html .= "</div>\n";
+                $ct++;
             }
         }
         return $html;
     }
-
 }

--- a/app/src/ToolsAn.php
+++ b/app/src/ToolsAn.php
@@ -1,105 +1,65 @@
 <?php
+declare(strict_types=1);
 
 namespace Tools;
 
-class ToolsAn{
-
-    function dd(array $arr)
+class ToolsAn
+{
+    public function dd(array $arr): void
     {
-    
-    echo "<pre>";
-
-    print_r($arr);
-
-    echo "</pre>";
-    
+        echo '<pre>';
+        print_r($arr);
+        echo '</pre>';
     }
 
-    static function filtArray(array $arr)
+    public static function filtArray(array $arr): array|false
     {
         $arr = array_filter($arr);
-        if(count($arr))
-        {
-            $rt = array();
-
-            foreach($arr as $arrayValue)
-            {
-                array_push($rt, $arrayValue);
+        if (count($arr)) {
+            $rt = [];
+            foreach ($arr as $arrayValue) {
+                $rt[] = $arrayValue;
             }
-    
             return $rt;
-        }else{
-            return false;
         }
-
+        return false;
     }
 
-    static function post(string $field)
+    public static function post(string $field): array|string|false
     {
-        if(isset($_POST[$field]))
-        {
-            return $_POST[$field];
-        }
-        else
-        {
-            return false;
-        }
+        $value = filter_input(INPUT_POST, $field, FILTER_DEFAULT);
+        return $value !== null ? $value : false;
     }
-    private function verifyPrexi(string $prefix, $val)
+    private function verifyPrexi(string $prefix, int|string $val): int|string|false
     {
-        $prefix = explode(":",$prefix);
-  
-        switch($prefix[0])
-        {
-  
-           case "min":
-  
-              if($prefix[1] != 'null')
-              {
-  
-                 $val = ($val >= $prefix[1])?$val:false;
-  
-                 return $val;
-  
-              }
-  
-              else
-              {
-  
-                 return $val;
-  
-              }
-  
-              break;
-        }
-    }
-
-    function validate(string $field,string $type, string $qt = "min:null")
-    {
-       
-        $val = $this->post($field);
-        if($val != false)
-        {
-          switch($type)
-           {
-              case "number":
-  
-                $val =preg_replace('/[^0-9]/','',$val);
-                if(($this->verifyPrexi($qt,$val)) != false)
-                {
-  
-                 return $val;
-  
+        $prefix = explode(':', $prefix);
+        switch ($prefix[0]) {
+            case 'min':
+                if ($prefix[1] !== 'null') {
+                    $val = ($val >= $prefix[1]) ? $val : false;
+                    return $val;
                 }
-                else
-                {
-  
-                   return false;
-  
-                }            
-              break;
-           }
+
+                return $val;
         }
+
+        return false;
+    }
+
+    public function validate(string $field, string $type, string $qt = 'min:null'): int|string|false
+    {
+        $val = self::post($field);
+        if ($val === false) {
+            return false;
+        }
+
+        switch ($type) {
+            case 'number':
+                $val = preg_replace('/[^0-9]/', '', (string)$val);
+                return $this->verifyPrexi($qt, $val);
+        }
+
+        return false;
     }
 
 }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3.0",
+        "php": "^8.0",
         "twig/twig": "^3.3"
     },
     "autoload": {

--- a/public/index.php
+++ b/public/index.php
@@ -1,7 +1,14 @@
 <?php
-// ini_set('display_errors',1);
-// ini_set('display_startup_erros',1);
-// error_reporting(E_ALL);
-require_once __DIR__.'/../vendor/autoload.php';
+declare(strict_types=1);
 
-new Core\RouteCore;
+// ini_set('display_errors',1);
+// ini_set('display_startup_errors',1);
+// error_reporting(E_ALL);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+if (!defined('HOME')) {
+    define('HOME', dirname(__DIR__));
+}
+
+new Core\RouteCore();


### PR DESCRIPTION
## Summary
- add `declare(strict_types=1)` and type hints
- remove old style constructors and modernize the style
- sanitize POST access and update routing logic
- define HOME constant and require PHP 8 in composer

## Testing
- `php -l app/core/RouteCore.php`
- `php -l public/index.php`
- `find app -name '*.php' -print | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_687ef0cd2e20832182f118754c4db842